### PR TITLE
Fix client and GMEPO offers api version

### DIFF
--- a/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
+++ b/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
@@ -28,8 +28,8 @@ class GMEPublicOfferQuery:
 
         queryParameters = _GMEPublicOfferQueryParameters()
         self._queryParameters = queryParameters
-        self._client = client
-        self._executor = requestExecutor
+        self.__client = client
+        self.__executor = requestExecutor
 
     def withPagination(
         self: GMEPublicOfferQuery, pagenumber: int, pagesize: int
@@ -445,9 +445,9 @@ class GMEPublicOfferQuery:
         return rr
 
     async def _execAsync(self: GMEPublicOfferQuery, urls: List[str]) -> list:
-        with self._client as c:
+        with self.__client as c:
             res = await asyncio.gather(
-                *[self._requestExecutor.exec(c.exec, "GET", i, None) for i in urls]
+                *[self.__executor.exec(c.exec, "GET", i, None) for i in urls]
             )
             return list(itertools.chain(*res))
 

--- a/src/Artesian/GMEPublicOffers/GMEPublicOfferService.py
+++ b/src/Artesian/GMEPublicOffers/GMEPublicOfferService.py
@@ -16,7 +16,7 @@ class GMEPublicOfferService:
     """
 
     __offerstype = "gmepublicoffer"
-    __version = "v1.0"
+    __version = "v2.0"
 
     def __init__(self: GMEPublicOfferService, artesianConfig: ArtesianConfig) -> None:
         """


### PR DESCRIPTION
Fixed client executor on GME PO that was wrongly assigned
Fixed GME PO API version, bumped to 2.0