### PR TITLE
Fix return handling of GMEPO data

### DIFF
--- a/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
+++ b/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
@@ -15,7 +15,6 @@ from ._Enum.UnitType import UnitType
 from ._Enum.Zone import Zone
 import asyncio
 from urllib import parse
-import itertools
 
 
 class GMEPublicOfferQuery:

--- a/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
+++ b/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
@@ -208,8 +208,8 @@ class GMEPublicOfferQuery:
         Returns:
             list of GMEPublicOffers.
         """
-        urls = self.__buildRequest()
-        return self._exec(urls)
+        url = self.__buildRequest()
+        return self._exec(url)
 
     async def executeAsync(self: GMEPublicOfferQuery) -> Any:
         """
@@ -218,13 +218,12 @@ class GMEPublicOfferQuery:
         Returns:
             Enumerable of TimeSerieRow Actual.
         """
-        urls = self.__buildRequest()
-        return await self._execAsync(urls)
+        url = self.__buildRequest()
+        return await self._execAsync(url)
 
     def __buildRequest(self: GMEPublicOfferQuery) -> str:
         self._validateQuery()
         qp = self._queryParameters
-        urls = []
 
         url = "/{0}/{1}/{2}/{3}?_=1".format(
             self.__routePrefix,
@@ -280,9 +279,7 @@ class GMEPublicOfferQuery:
             enc = parse.quote_plus(baType)
             url = url + "&baType=" + enc
 
-        urls.append(url)
-
-        return urls
+        return url
 
     def __getScope(self: GMEPublicOfferQuery, scope: Scope) -> str:
         switcher = {
@@ -440,15 +437,15 @@ class GMEPublicOfferQuery:
         subPath = f"{parse.quote_plus(purpose)}"
         return subPath
 
-    def _exec(self: GMEPublicOfferQuery, urls: List[str]) -> list:
+    def _exec(self: GMEPublicOfferQuery, url: str) -> Any:
         loop = get_event_loop()
-        rr = loop.run_until_complete(self._execAsync(urls))
+        rr = loop.run_until_complete(self._execAsync(url))
         return rr
 
-    async def _execAsync(self: GMEPublicOfferQuery, urls: List[str]) -> list:
+    async def _execAsync(self: GMEPublicOfferQuery, url: str) -> Any:
         with self.__client as c:
             res = await asyncio.gather(
-                *[self.__executor.exec(c.exec, "GET", i, None) for i in urls]
+                *[self.__executor.exec(c.exec, "GET", url, None)]
             )
             return res[0]
 

--- a/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
+++ b/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
@@ -451,7 +451,7 @@ class GMEPublicOfferQuery:
             res = await asyncio.gather(
                 *[self.__executor.exec(c.exec, "GET", i, None) for i in urls]
             )
-            return list(itertools.chain(*res))
+            return res[0]
 
     def __toUrlParam(self: GMEPublicOfferQuery, date: str) -> str:
         return f"{date}"

--- a/tests/TestGMEPO.py
+++ b/tests/TestGMEPO.py
@@ -43,7 +43,7 @@ class TestGMEPO(unittest.TestCase):
             .execute()
         )
 
-        query = requests.getPOQs()
+        query = requests.getQs()
         self.assertEqual(query["market"], "MGP")
 
     @helpers.TrackGMEPORequests
@@ -57,7 +57,7 @@ class TestGMEPO(unittest.TestCase):
             .execute()
         )
 
-        query = requests.getPOQs()
+        query = requests.getQs()
         self.assertEqual(query["market"], "MGP,MI1,MIA2,MIXBID")
 
     @helpers.TrackGMEPORequests
@@ -71,7 +71,7 @@ class TestGMEPO(unittest.TestCase):
             .execute()
         )
 
-        query = requests.getPOQs()
+        query = requests.getQs()
         self.assertEqual(query["zone"], "NORD")
 
     @helpers.TrackGMEPORequests
@@ -85,7 +85,7 @@ class TestGMEPO(unittest.TestCase):
             .execute()
         )
 
-        query = requests.getPOQs()
+        query = requests.getQs()
         self.assertEqual(query["zone"], "NORD,SUD")
 
     @helpers.TrackGMEPORequests
@@ -100,7 +100,7 @@ class TestGMEPO(unittest.TestCase):
             .execute()
         )
 
-        query = requests.getPOQs()
+        query = requests.getQs()
         self.assertEqual(query["page"], "1")
         self.assertEqual(query["pageSize"], "100")
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,6 +19,14 @@ class Qs:
             )
         )
 
+    def getPOQs(self: Qs) -> Dict[str, str]:
+        return dict(
+            map(
+                lambda x: x.split("="),
+                unquote(self._mock.call_args.args[0]).split("?")[1].split("&"),
+            )
+        )
+
     def getPath(self: Qs) -> str:
         return urlparse(self._mock.call_args.args[0][0]).path
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,20 +15,29 @@ class Qs:
         return dict(
             map(
                 lambda x: x.split("="),
-                unquote(self._mock.call_args.args[0][0]).split("?")[1].split("&"),
-            )
-        )
-
-    def getPOQs(self: Qs) -> Dict[str, str]:
-        return dict(
-            map(
-                lambda x: x.split("="),
-                unquote(self._mock.call_args.args[0]).split("?")[1].split("&"),
+                unquote(urlparse(self._mock.call_args.args[0][0]).query).split("&"),
             )
         )
 
     def getPath(self: Qs) -> str:
         return urlparse(self._mock.call_args.args[0][0]).path
+
+
+class QsPO:
+
+    def __init__(self: QsPO, mock: Mock) -> None:
+        self._mock = mock
+
+    def getQs(self: QsPO) -> Dict[str, str]:
+        return dict(
+            map(
+                lambda x: x.split("="),
+                unquote(urlparse(self._mock.call_args.args[0]).query).split("&"),
+            )
+        )
+
+    def getPath(self: Qs) -> str:
+        return urlparse(self._mock.call_args.args[0]).path
 
 
 def TrackRequests(func: Callable) -> Callable[[Any, Qs], None]:
@@ -42,6 +51,6 @@ def TrackRequests(func: Callable) -> Callable[[Any, Qs], None]:
 def TrackGMEPORequests(func: Callable) -> Callable[[Any, Qs], None]:
     @patch.object(_GMEPO.GMEPublicOfferQuery, "_exec")
     def wrapper(self: Any, mock: Mock) -> None:
-        func(self, Qs(mock))
+        func(self, QsPO(mock))
 
     return wrapper


### PR DESCRIPTION
An issue has been identified regarding the handling of the GME PO data return. 
Instead of simply passing the returned JSON to the deserializer, it was mistakenly treated as a list of dictionaries, similar to TS requests. 
This resulted in the loss of values, with only the header of the items being returned in the payload.

Fix Applied: Restore the correct behaviour, passing the JSON to the deserializer