### PR TITLE
Fix operators parameter and added missing markets to enum

### DIFF
--- a/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
+++ b/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
@@ -262,7 +262,7 @@ class GMEPublicOfferQuery:
             sep = ","
             operator = sep.join(map(str, qp.operator))
             enc = parse.quote_plus(operator)
-            url = url + "&operator=" + enc
+            url = url + "&operators=" + enc
         if not (qp.zone is None):
             sep = ","
             zone = sep.join(map(lambda x: self.__getZone(x), qp.zone))
@@ -342,6 +342,8 @@ class GMEPublicOfferQuery:
             Market.MIA1: "MIA1",
             Market.MIA2: "MIA2",
             Market.MIA3: "MIA3",
+            Market.MRR: "MRR",
+            Market.AFRR: "AFRR",
         }
         vr = switcher.get(market, "DefMarket")
         if vr == "DefMarket":

--- a/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
+++ b/src/Artesian/GMEPublicOffers/GMEPublicOfferQuery.py
@@ -115,19 +115,19 @@ class GMEPublicOfferQuery:
         self._queryParameters.unit = unit
         return self
 
-    def forOperator(
-        self: GMEPublicOfferQuery, operator: List[str]
+    def forOperators(
+        self: GMEPublicOfferQuery, operators: List[str]
     ) -> GMEPublicOfferQuery:
         """
         Set the operators to be queried.
 
         Args:
-            operator: string for the GME Public Offer operator to be queried.
+            operators: string for the GME Public Offer operators to be queried.
 
         Returns:
             GMEPublicOfferQuery.
         """
-        self._queryParameters.operator = operator
+        self._queryParameters.operators = operators
         return self
 
     def forZone(self: GMEPublicOfferQuery, zone: List[Zone]) -> GMEPublicOfferQuery:
@@ -258,10 +258,10 @@ class GMEPublicOfferQuery:
             )
             enc = parse.quote_plus(generationType)
             url = url + "&generationType=" + enc
-        if not (qp.operator is None):
+        if not (qp.operators is None):
             sep = ","
-            operator = sep.join(map(str, qp.operator))
-            enc = parse.quote_plus(operator)
+            operators = sep.join(map(str, qp.operators))
+            enc = parse.quote_plus(operators)
             url = url + "&operators=" + enc
         if not (qp.zone is None):
             sep = ","

--- a/src/Artesian/GMEPublicOffers/GMEPublicOfferQueryParameters.py
+++ b/src/Artesian/GMEPublicOffers/GMEPublicOfferQueryParameters.py
@@ -20,7 +20,7 @@ class _GMEPublicOfferQueryParameters:
         status: sets the Status to be queried.
         unitType: sets the unit types to be queried.
         generationType: that sets the generation type to be queried.
-        operator: sets the operators to be queried.
+        operators: sets the operators to be queried.
         unit: sets the units to be queried.
         zone: sets the zones to be queried.
         market: sets the Market to be queried.
@@ -39,7 +39,7 @@ class _GMEPublicOfferQueryParameters:
         status: Optional[Status] = None,
         unitType: Optional[List[UnitType]] = None,
         generationType: Optional[List[GenerationType]] = None,
-        operator: Optional[List[str]] = None,
+        operators: Optional[List[str]] = None,
         unit: Optional[List[str]] = None,
         zone: Optional[List[Zone]] = None,
         market: Optional[List[Market]] = None,
@@ -57,7 +57,7 @@ class _GMEPublicOfferQueryParameters:
             status:An enum that sets the Status to be queried.
             unitType: An enum that sets the unit types to be queried.
             generationType: An enum that sets the generation type to be queried.
-            operator: A string that sets the operators to be queried.
+            operators: A string that sets the operators to be queried.
             unit: A string that sets the units to be queried.
             zone: An enum that sets the zones to be queried.
             market: An enum that sets the Market to be queried.
@@ -72,7 +72,7 @@ class _GMEPublicOfferQueryParameters:
         self.status = status
         self.unitType = unitType
         self.generationType = generationType
-        self.operator = operator
+        self.operators = operators
         self.unit = unit
         self.zone = zone
         self.market = market

--- a/tests/TestGMEPO.py
+++ b/tests/TestGMEPO.py
@@ -89,6 +89,20 @@ class TestGMEPO(unittest.TestCase):
         self.assertEqual(query["zone"], "NORD,SUD")
 
     @helpers.TrackGMEPORequests
+    def test_Operator(self, requests):
+        url = (
+            qs.createQuery()
+            .forDate("2020-04-01")
+            .forOperators(["Test"])
+            .forStatus(Status.ACC)
+            .forPurpose(Purpose.BID)
+            .execute()
+        )
+
+        query = requests.getQs()
+        self.assertEqual(query["operators"], "Test")
+
+    @helpers.TrackGMEPORequests
     def test_Pagination(self, requests):
         url = (
             qs.createQuery()


### PR DESCRIPTION
The following changes has been applied on the GME Public offers extraction:

"operator" filed has been fixed in the query builder, it is now "operators" as expected from the API
Has been added the missing market MRR and AFRR to the supported markets enum  