### PR TITLE
Fix the FilterId params on Version Extraction

### DIFF
--- a/src/Artesian/Query/VersionedQuery.py
+++ b/src/Artesian/Query/VersionedQuery.py
@@ -376,7 +376,7 @@ class VersionedQuery(_Query):
                 enc = parse.quote_plus(ids)
                 url = url + "&id=" + enc
             if not (qp.filterId is None):
-                url = url + "&filterId=" + "qp.filterId"
+                url = url + "&filterId=" + str(qp.filterId)
             if not (qp.timezone is None):
                 url = url + "&tz=" + qp.timezone
             if not (qp.transformId is None):

--- a/tests/TestActual.py
+++ b/tests/TestActual.py
@@ -37,6 +37,7 @@ class TestActual(unittest.TestCase):
         )
 
         self.assertEqual(requests.getQs()["fillerK"], "NoFill")
+        self.assertEqual(requests.getQs()["filterId"], "1003")
 
     @helpers.TrackRequests
     def test_Latest_Fill(self, requests):

--- a/tests/TestVersioned.py
+++ b/tests/TestVersioned.py
@@ -60,6 +60,7 @@ class TestVersioned(unittest.TestCase):
         self.assertEqual(query["fillerK"], "LatestValidValue")
         self.assertEqual(query["fillerP"], "P5D")
         self.assertEqual(query["fillerC"], "False")
+        self.assertEqual(query["filterId"], "1003")
 
     @helpers.TrackRequests
     def test_Latest_Fill_Continue(self: TestVersioned, requests: Qs) -> None:


### PR DESCRIPTION
The FilterID parameter was not correctly handled in the versioned TS Extraction