### PR TITLE
fix: prevent error in ReadMarketData when UnitOfMeasure is null

### DIFF
--- a/src/Artesian/MarketData/_Dto/UnitOfMeasure.py
+++ b/src/Artesian/MarketData/_Dto/UnitOfMeasure.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -12,4 +13,4 @@ class UnitOfMeasure:
 
     """
 
-    value: str
+    value: Optional[str]


### PR DESCRIPTION
Reviewed-by: Niccolo Cecchi
Refs: #20459